### PR TITLE
RecvonlyClient で secretKey がある場合にのみ access_token を設定するように修正する

### DIFF
--- a/check_stereo/main.ts
+++ b/check_stereo/main.ts
@@ -310,8 +310,12 @@ class RecvonlyClient {
   }
 
   async connect(): Promise<void> {
-    const jwt = await generateJwt(this.channelId, this.secretKey);
-    this.connection.metadata = { access_token: jwt };
+    if (this.secretKey) {
+      const jwt = await generateJwt(this.channelId, this.secretKey);
+      this.connection.metadata = {
+        access_token: jwt,
+      };
+    }
 
     const forceStereoOutputElement = document.querySelector<HTMLInputElement>("#forceStereoOutput");
     const forceStereoOutput = forceStereoOutputElement ? forceStereoOutputElement.checked : false;


### PR DESCRIPTION
SendonlyClient と同様に、RecvonlyClient でも secretKey がある場合にのみ access_token を設定するように修正しました。